### PR TITLE
Возможность настраивать Content-Type в FinishJSON

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,10 @@
 package request
 
+// ErrInitializedAlready already initialized error
 type ErrInitializedAlready bool
+
 const errInitializedAlready = ErrInitializedAlready(true)
+
 func (err ErrInitializedAlready) Error() string {
 	return "the request package has been initialized already"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
-module github.com/elemc/request
+module github.com/St0rmPetrel/request
 
-go 1.12
+go 1.16
 
 require (
-	github.com/gorilla/mux v1.7.3
-	github.com/sirupsen/logrus v1.4.2
+	github.com/elemc/request v0.0.0-20211020085020-156e0f0ec2ce
+	github.com/gorilla/mux v1.8.0
+	github.com/sirupsen/logrus v1.8.1
 )

--- a/request.go
+++ b/request.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// DefaultBodySize - стандартное ограничение в 1мб для вывода body запроса в logger
-	DefaultBodySize = 1<<20
+	DefaultBodySize = 1 << 20
 )
 
 var (
@@ -27,7 +27,7 @@ var (
 	metricsWithMethods bool
 
 	// Настройки для вывода body в логах
-	logBody = true
+	logBody   = true
 	bodyLimit = DefaultBodySize
 )
 
@@ -198,7 +198,9 @@ func (r *Request) FinishJSON(code int, i interface{}) {
 		return
 	}
 
-	r.w.Header().Set("Content-Type", "application/json")
+	if r.w.Header().Get("Content-Type") == "" {
+		r.w.Header().Set("Content-Type", "application/json")
+	}
 	r.w.WriteHeader(code)
 	if _, err := r.w.Write(data); err != nil {
 		r.Log().Warnf("Unable to write data: %s", err)

--- a/request.go
+++ b/request.go
@@ -84,6 +84,11 @@ func New(w http.ResponseWriter, r *http.Request) (request *Request) {
 	return
 }
 
+// GetURL возвращает URL запроса
+func (r *Request) GetURL() *url.URL {
+	return r.r.URL
+}
+
 var initializer sync.Once
 
 // Setup - функция устанавливает логгер и коллбэки

--- a/request_test.go
+++ b/request_test.go
@@ -33,7 +33,8 @@ func (mw *mockWriter) WriteHeader(statusCode int) {
 func testRequest() (err error) {
 	handler := func(w http.ResponseWriter, r *http.Request) {}
 	logrus.SetLevel(logrus.ErrorLevel)
-	request.Setup(logrus.StandardLogger(), nil, nil)
+	request.Setup(logrus.StandardLogger(), false, request.DefaultBodySize,
+		nil, nil)
 
 	router := mux.NewRouter()
 	router.HandleFunc("/test/uri", handler)


### PR DESCRIPTION
Добавил возможность самостоятельно настроить Хедер "Content-Type"
в случае когда отвечаем JSON-ом, так как он не всегда
"application/json", например в случае JSON:API - "aplication/vnd.api+json"
Поменял вызов функции Setup в тестах